### PR TITLE
Allow using an existing user pool

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -18,6 +18,7 @@ Metadata:
         Label:
           default: "Dev Portal Customer Configuration"
         Parameters:
+          - CognitoUserPoolId
           - CognitoIdentityPoolName
           - DevPortalCustomersTableName
       -
@@ -80,6 +81,11 @@ Parameters:
     Description: The marketplace SNS topic suffix for subscription/unsubscription events
     Default: DevPortalMarketplaceSubscriptionTopic
 
+  CognitoUserPoolId:
+    Type: String
+    Description: The ID of an existing User Pool, if exists. If unsupplied, a new user pool will be created.
+    Default: ''
+
   CognitoIdentityPoolName:
     Type: String
     Description: The name for your Cognito Identity Pool.
@@ -122,6 +128,7 @@ Conditions:
   DevelopmentMode: !Equals [!Ref DevelopmentMode, 'true']
   NotDevelopmentMode: !Not [!Condition DevelopmentMode]
   InUSEastOne: !Equals [!Ref 'AWS::Region', 'us-east-1']
+  CreateNewUserPool: !Equals [!Ref CognitoUserPoolId, '']
 
 Resources:
   ApiGatewayApi:
@@ -1030,6 +1037,7 @@ Resources:
       Timeout: 3
 
   CognitoUserPool:
+    Condition: CreateNewUserPool
     Type: AWS::Cognito::UserPool
     Properties:
       UserPoolName: !Ref CognitoIdentityPoolName
@@ -1052,7 +1060,7 @@ Resources:
     # However, when this is updated and changes, the CUPCS custom resource doesn't re-run, and so a bunch of vital
     # settings won't be set, e.g., CallbackURL.
     Properties:
-      UserPoolId: !Ref CognitoUserPool
+      UserPoolId: !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
       ClientName: CognitoIdentityPool
       GenerateSecret: false
       RefreshTokenValidity: 30
@@ -1104,7 +1112,7 @@ Resources:
     Properties:
       Timeout: 360
       ServiceToken: !GetAtt CognitoUserPoolClientSettingsBackingFn.Arn
-      UserPoolId: !Ref CognitoUserPool
+      UserPoolId: !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
       UserPoolClientId: !Ref CognitoUserPoolClient
       SupportedIdentityProviders: [ "COGNITO" ] # should (eventually) allow people to add values
       CallbackURL: !If [ DevelopmentMode,
@@ -1184,7 +1192,7 @@ Resources:
     Properties:
       Timeout: 360
       ServiceToken: !GetAtt CognitoUserPoolDomainBackingFn.Arn
-      UserPoolId: !Ref CognitoUserPool
+      UserPoolId: !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
       Domain: !Ref CognitoDomainNameOrPrefix
   
   CognitoIdentityPool:
@@ -1296,7 +1304,7 @@ Resources:
       # since admin group has a precedence of 0, it takes priority
       Precedence: 0
       RoleArn: !GetAtt CognitoAdminRole.Arn
-      UserPoolId: !Ref CognitoUserPool
+      UserPoolId: !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
 
   CatalogUpdaterLambdaFunction:
     Type: AWS::Serverless::Function
@@ -1342,7 +1350,7 @@ Resources:
       RestApiId: !Ref ApiGatewayApi
       Region: !Ref 'AWS::Region'
       IdentityPoolId: !Ref CognitoIdentityPool
-      UserPoolId: !Ref CognitoUserPool
+      UserPoolId: !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
       UserPoolClientId: !Ref CognitoUserPoolClient
       UserPoolDomain: !GetAtt CognitoUserPoolDomain.FullUrl
       MarketplaceSuffix: !Ref MarketplaceSubscriptionTopicProductCode

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -86,6 +86,11 @@ Parameters:
     Description: The ID of an existing User Pool, if exists. If unsupplied, a new user pool will be created.
     Default: ''
 
+  ExistingUserPoolDomain:
+    Type: String
+    Description: The Domain of the existing User Pool, if exists. Must be supplied for an existing User Pool.
+    Default: ''
+
   CognitoIdentityPoolName:
     Type: String
     Description: The name for your Cognito Identity Pool.
@@ -955,7 +960,7 @@ Resources:
           - ':'
           - !Ref 'AWS::AccountId'
           - ':userpool/'
-          - !Ref CognitoUserPool
+          - !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
 
   LambdaSNSExecutionPermission:
     Type: AWS::Lambda::Permission
@@ -1188,6 +1193,7 @@ Resources:
       Role: !GetAtt CognitoUserPoolDomainBackingFnRole.Arn
 
   CognitoUserPoolDomain:
+    Condition: CreateNewUserPool
     Type: AWS::CloudFormation::CustomResource
     Properties:
       Timeout: 360
@@ -1207,7 +1213,7 @@ Resources:
             - - cognito-idp.
               - !Ref 'AWS::Region'
               - .amazonaws.com/
-              - !Ref CognitoUserPool
+              - !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
 
   CognitoIdentityPoolRoles:
     Type: AWS::Cognito::IdentityPoolRoleAttachment
@@ -1352,7 +1358,7 @@ Resources:
       IdentityPoolId: !Ref CognitoIdentityPool
       UserPoolId: !If [CreateNewUserPool, !Ref CognitoUserPool, !Ref CognitoUserPoolId]
       UserPoolClientId: !Ref CognitoUserPoolClient
-      UserPoolDomain: !GetAtt CognitoUserPoolDomain.FullUrl
+      UserPoolDomain: !If [CreateNewUserPool, !GetAtt CognitoUserPoolDomain.FullUrl, !Ref ExistingUserPoolDomain]
       MarketplaceSuffix: !Ref MarketplaceSubscriptionTopicProductCode
       RebuildToken: !Ref StaticAssetRebuildToken
       RebuildMode: !Ref StaticAssetRebuildMode


### PR DESCRIPTION
*Description of changes:*
Added a user pool id parameter, which when supplied - connects the entire stack to the existing user pool, instead of creating a new one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
